### PR TITLE
Add Retrofit

### DIFF
--- a/app/src/main/java/com/example/atackontitanapi/core/data/remote/api/ApiCall.kt
+++ b/app/src/main/java/com/example/atackontitanapi/core/data/remote/api/ApiCall.kt
@@ -1,0 +1,28 @@
+package com.example.atackontitanapi.core.data.remote.api
+
+import com.example.atackontitanapi.core.domain.ErrorApp
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import retrofit2.Response
+import java.io.IOException
+
+suspend fun <T> apiCall(
+    call: suspend () -> Response<T>
+): Result<T> {
+    return withContext(Dispatchers.IO) {
+        try {
+            val response = call()
+            if (response.isSuccessful && response.body() != null) {
+                Result.success(response.body()!!)
+            } else if (response.code() == 404) {
+                Result.failure(ErrorApp.NotFoundError)
+            } else {
+                Result.failure(ErrorApp.ServerError)
+            }
+        } catch (e: IOException) {
+            Result.failure(ErrorApp.NetworkError)
+        } catch (e: Exception) {
+            Result.failure(ErrorApp.ServerError)
+        }
+    }
+}

--- a/app/src/main/java/com/example/atackontitanapi/core/data/remote/api/ApiClient.kt
+++ b/app/src/main/java/com/example/atackontitanapi/core/data/remote/api/ApiClient.kt
@@ -1,0 +1,19 @@
+package com.example.atackontitanapi.core.data.remote.api
+
+import org.koin.core.annotation.Single
+import retrofit2.Retrofit
+import retrofit2.converter.gson.GsonConverterFactory
+
+@Single
+class ApiClient {
+    private val BASE_URL = "https://api.attackontitanapi.com/"
+
+    private val retrofit = Retrofit.Builder()
+        .baseUrl(BASE_URL)
+        .addConverterFactory(GsonConverterFactory.create())
+        .build()
+
+    fun <T> createService(serviceClass: Class<T>): T {
+        return retrofit.create(serviceClass)
+    }
+}

--- a/app/src/main/java/com/example/atackontitanapi/core/domain/ErrorApp.kt
+++ b/app/src/main/java/com/example/atackontitanapi/core/domain/ErrorApp.kt
@@ -1,0 +1,8 @@
+package com.example.atackontitanapi.core.domain
+
+sealed class ErrorApp : Exception() {
+    data object NetworkError : ErrorApp()
+    data object ServerError : ErrorApp()
+    data object NotFoundError : ErrorApp()
+    data object DataParseError : ErrorApp()
+}


### PR DESCRIPTION
name: Integrar Retrofit y manejo de errores
title: "[Task]: Integrar Retrofit, apiCall y gestión de errores"
labels: ["task"]
projects: ["Simpsons-API"]
assignees: danilop418

---

## 🤔 Breve descripción del problema a resolver
La aplicación no contaba con un cliente HTTP definido ni con un sistema centralizado para realizar llamadas a la API y gestionar errores, lo que dificultaba la reutilización del código y el mantenimiento de la capa Data.

## 💡 Proceso seguido para resolver el problema
- Configuración de Retrofit como cliente HTTP  
- Creación del servicio de la API  
- Implementación de una función genérica `apiCall`  
- Centralización del manejo de errores de red y servidor  
- Integración con la arquitectura existente  
- Apoyo con Inteligencia Artificial (Grok)(Claude)(Kimi)(DeepSeek)(DeepWiki)

## 👩‍💻 Resumen técnico de la Solución

**Pasos lógicos:**
1. Implementar Retrofit para realizar llamadas HTTP.
2. Definir el `ApiService` con los endpoints necesarios.
3. Crear `apiCall` como recurso compartido para peticiones.
4. Centralizar la gestión de errores y excepciones.
5. Integrar la solución en los data sources remotos.

## 📸 Screenshot o Video
*(No aplica para esta PR)*

## ✋ Notas adicionales (Disclaimer)
- No se ha modificado la lógica de negocio.
- La implementación facilita la reutilización y el mantenimiento del código.

## 🌈 GIF representativo de esta PR
![🌐 Retrofit](https://media.giphy.com/media/xT0GqssRweIhlz209i/giphy.gif)
*(¡Conexión con la API lista! 🚀)*

## ✅ Checklist
- [x] La rama tiene el formato correcto: `task/XX-retrofit-setup`
- [x] He añadido un título a la PR descriptivo.
- [x] Me he asignado como autor.
- [x] He asignado a dos revisores.
- [x] He relacionado la PR con la Issue correspondiente.

### Commits realizados
- Implementado Retrofit.
- Implementado `apiCall` como recurso compartido.
- Añadida la gestión centralizada de errores.
