### PR TITLE
Create xml cache

### DIFF
--- a/app/src/main/java/com/example/atackontitanapi/core/data/local/xml/XmlModel.kt
+++ b/app/src/main/java/com/example/atackontitanapi/core/data/local/xml/XmlModel.kt
@@ -1,0 +1,6 @@
+package com.example.atackontitanapi.core.data.local.xml
+
+interface XmlModel {
+    fun getId(): String
+    fun getPersistedTime(): Long
+}


### PR DESCRIPTION
name: Implementar caché para el listado de personajes
title: "[Feature]: Implementar caché para el listado de personajes"
labels: ["feature"]
projects: ["Atack on titan-API"]
assignees: daniellopgon

---

## 🤔 Breve descripción del problema a resolver
El listado de personajes dependía exclusivamente de llamadas a red, lo que provocaba recargas innecesarias y una peor experiencia de usuario en ausencia de conexión.

## 💡 Proceso seguido para resolver el problema
- Revisión de la arquitectura existente  
- Implementación de un sistema de caché local reutilizable  
- Integración de la caché en el flujo de obtención del listado  
- Pruebas de guardado y lectura de datos cacheados  

## 👩‍💻 Resumen técnico de la Solución

**Pasos lógicos:**
1. Implementar la caché local para el listado de personajes  
2. Guardar los datos obtenidos desde la API en caché  
3. Leer desde caché cuando los datos están disponibles  

## 📸 Screenshot o Video
_No aplica_

## ✋ Notas adicionales (Disclaimer)
- La caché mejora el rendimiento y reduce llamadas innecesarias a la API.
- Prepara la app para futuras mejoras como soporte offline.

## 🌈 GIF representativo de esta PR
![Cache implemented](https://media.giphy.com/media/3o7aD2saalBwwftBIY/giphy.gif)
*(¡Datos más rápidos y eficientes! ⚡)*

## ✅ Checklist
- [x] La rama tiene el formato correcto
- [x] La PR tiene un título descriptivo
- [x] Se ha implementado la caché del listado de personajes
- [x] No se rompe la funcionalidad existente
- [x] El proyecto compila y funciona correctamente
