### PR TITLE
 Add error handling

### DIFF
--- a/app/src/main/java/com/example/atackontitanapi/core/data/remote/api/ApiCall.kt
+++ b/app/src/main/java/com/example/atackontitanapi/core/data/remote/api/ApiCall.kt
@@ -15,14 +15,14 @@ suspend fun <T> apiCall(
             if (response.isSuccessful && response.body() != null) {
                 Result.success(response.body()!!)
             } else if (response.code() == 404) {
-                Result.failure(ErrorApp.NotFoundError)
+                Result.failure(ErrorApp.InternetConexionError)
             } else {
-                Result.failure(ErrorApp.ServerError)
+                Result.failure(ErrorApp.ServerErrorApp)
             }
         } catch (e: IOException) {
-            Result.failure(ErrorApp.NetworkError)
+            Result.failure(ErrorApp.InternetConexionError)
         } catch (e: Exception) {
-            Result.failure(ErrorApp.ServerError)
+            Result.failure(ErrorApp.ServerErrorApp)
         }
     }
 }

--- a/app/src/main/java/com/example/atackontitanapi/core/domain/ErrorApp.kt
+++ b/app/src/main/java/com/example/atackontitanapi/core/domain/ErrorApp.kt
@@ -1,8 +1,7 @@
 package com.example.atackontitanapi.core.domain
 
-sealed class ErrorApp : Exception() {
-    data object NetworkError : ErrorApp()
-    data object ServerError : ErrorApp()
-    data object NotFoundError : ErrorApp()
-    data object DataParseError : ErrorApp()
+sealed class ErrorApp : Throwable() {
+    object InternetConexionError : ErrorApp()
+    object ServerErrorApp : ErrorApp()
+    object CacheError : ErrorApp()
 }

--- a/app/src/main/java/com/example/atackontitanapi/core/presentation/errors/ErrorAppFactory.kt
+++ b/app/src/main/java/com/example/atackontitanapi/core/presentation/errors/ErrorAppFactory.kt
@@ -1,0 +1,14 @@
+package com.example.atackontitanapi.core.presentation.errors
+
+import android.content.Context
+import com.example.atackontitanapi.core.domain.ErrorApp
+
+class ErrorAppFactory(private val context: Context) {
+    fun build(errorApp: ErrorApp, onRetry: () -> Unit): ErrorAppUI {
+        return when (errorApp) {
+            is ErrorApp.InternetConexionError -> ConnectionErrorAppUI(context, onRetry)
+            is ErrorApp.ServerErrorApp -> ServerErrorAppUI(context, onRetry)
+            is ErrorApp.CacheError -> ServerErrorAppUI(context, onRetry)
+        }
+    }
+}

--- a/app/src/main/java/com/example/atackontitanapi/core/presentation/errors/ErrorAppUI.kt
+++ b/app/src/main/java/com/example/atackontitanapi/core/presentation/errors/ErrorAppUI.kt
@@ -1,0 +1,31 @@
+package com.example.atackontitanapi.core.presentation.errors
+
+import android.content.Context
+import com.example.atackontitanapi.R
+
+interface ErrorAppUI {
+    fun getImageError(): Int
+    fun getTitleError(): String
+    fun getDescriptionError(): String
+    fun getActionRetry(): Unit
+}
+
+class ConnectionErrorAppUI(
+    val context: Context,
+    val onClick: (() -> Unit)?
+) : ErrorAppUI {
+    override fun getImageError() = R.drawable.img_network_error
+    override fun getTitleError() = context.getString(R.string.title_error_connection)
+    override fun getDescriptionError() = context.getString(R.string.description_error_connection)
+    override fun getActionRetry() { onClick?.invoke() }
+}
+
+class ServerErrorAppUI(
+    val context: Context,
+    val onClick: (() -> Unit)?
+) : ErrorAppUI {
+    override fun getImageError() = R.drawable.img_unknow_error
+    override fun getTitleError() = context.getString(R.string.title_error_server)
+    override fun getDescriptionError() = context.getString(R.string.description_error_server)
+    override fun getActionRetry() { onClick?.invoke() }
+}

--- a/app/src/main/java/com/example/atackontitanapi/core/presentation/errors/ErrorAppView.kt
+++ b/app/src/main/java/com/example/atackontitanapi/core/presentation/errors/ErrorAppView.kt
@@ -1,0 +1,41 @@
+package com.example.atackontitanapi.core.presentation.errors
+
+import android.content.Context
+import android.util.AttributeSet
+import android.view.LayoutInflater
+import android.view.View
+import android.widget.FrameLayout
+import com.example.atackontitanapi.databinding.ViewErrorBinding
+
+class ErrorAppView @JvmOverloads constructor(
+    context: Context,
+    attrs: AttributeSet? = null
+) : FrameLayout(context, attrs) {
+
+    private val binding = ViewErrorBinding
+        .inflate(LayoutInflater.from(context), this, true)
+
+    init {
+        hide()
+    }
+
+    fun render(errorAppUI: ErrorAppUI) {
+        binding.apply {
+            errorImage.setImageResource(errorAppUI.getImageError())
+            titleErrorText.text = errorAppUI.getTitleError()
+            descriptionErrorText.text = errorAppUI.getDescriptionError()
+            retryErrorButton.setOnClickListener {
+                errorAppUI.getActionRetry()
+            }
+        }
+        visible()
+    }
+
+    fun hide() {
+        visibility = View.GONE
+    }
+
+    fun visible() {
+        visibility = View.VISIBLE
+    }
+}

--- a/app/src/main/res/drawable/img_network_error.xml
+++ b/app/src/main/res/drawable/img_network_error.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="120dp"
+    android:height="120dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="#FF5252"
+        android:pathData="M12,2C6.48,2 2,6.48 2,12s4.48,10 10,10 10,-4.48 10,-10S17.52,2 12,2zM13,17h-2v-2h2v2zM13,13h-2V7h2v6z"/>
+</vector>

--- a/app/src/main/res/drawable/img_unknow_error.xml
+++ b/app/src/main/res/drawable/img_unknow_error.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="120dp"
+    android:height="120dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="#FF9800"
+        android:pathData="M1,21h22L12,2 1,21zM13,18h-2v-2h2v2zM13,14h-2v-4h2v4z"/>
+</vector>

--- a/app/src/main/res/layout/view_error.xml
+++ b/app/src/main/res/layout/view_error.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:gravity="center"
+    android:orientation="vertical"
+    android:padding="32dp">
+
+    <ImageView
+        android:id="@+id/errorImage"
+        android:layout_width="120dp"
+        android:layout_height="120dp"
+        android:contentDescription="@string/error_icon" />
+
+    <TextView
+        android:id="@+id/titleErrorText"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="24dp"
+        android:textSize="20sp"
+        android:textStyle="bold" />
+
+    <TextView
+        android:id="@+id/descriptionErrorText"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="8dp"
+        android:gravity="center"
+        android:textSize="14sp" />
+
+    <Button
+        android:id="@+id/retryErrorButton"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="24dp"
+        android:text="@string/retry" />
+
+</LinearLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,3 +1,9 @@
 <resources>
     <string name="app_name">AtackOnTitanApi</string>
+    <string name="title_error_connection">Sin conexión</string>
+    <string name="description_error_connection">Comprueba tu conexión a internet e inténtalo de nuevo.</string>
+    <string name="title_error_server">Error del servidor</string>
+    <string name="description_error_server">Ha ocurrido un error. Por favor, inténtalo más tarde.</string>
+    <string name="retry">Reintentar</string>
+    <string name="error_icon">Icono de error</string>
 </resources>


### PR DESCRIPTION
name: Implementar manejo de errores centralizado
title: "[Feature]: Implementar manejo de errores centralizado"
labels: ["feature"]
projects: ["Atack on titan-API"]
assignees: daniellopgon
---

## 🤔 Breve descripción del problema a resolver
Actualmente la aplicación no tenía un manejo de errores unificado, lo que provocaba código duplicado y poco consistente al mostrar errores de red o servidor en la UI.

## 💡 Proceso seguido para resolver el problema
- Crear `ErrorApp` como sealed class para errores de dominio
- Implementar `ErrorAppUI` y sus variantes para la UI
- Crear `ErrorAppFactory` para mapear errores del dominio a UI
- Adaptar la función genérica `apiCall` para usar el nuevo sistema de errores
- Integrar el sistema de errores en la capa de presentación

## 👩‍💻 Resumen técnico de la Solución

**Pasos lógicos:**
1. Implementación de `ErrorApp` y sus variantes (`InternetConexionError`, `ServerErrorApp`, etc.)
2. Creación de `ErrorAppView` como vista reutilizable
3. Adaptación de `ApiCall` para retornar `Result.failure(ErrorApp)` según el tipo de excepción
4. Refactorización de Fragments y ViewModels para mostrar errores usando `ErrorAppView`

## 📸 Screenshot o Video

*(No aplica para esta PR)*

## ✋ Notas adicionales (Disclaimer)
- Se ha centralizado y estandarizado el manejo de errores en toda la app
- Se mantiene compatibilidad con la arquitectura existente

## 🌈 GIF representativo de esta PR
![🎯 Manejo de errores centralizado](https://media.giphy.com/media/l0MYt5jPR6QX5pnqM/giphy.gif)
*(¡Errores ahora manejados de forma limpia y consistente!)*

## ✅ Checklist
- [x] La rama tiene el formato correcto: `feature/XX-error-handling`
- [x] He añadido un título a la PR descriptivo
- [x] Me he asignado como autor
- [x] He asignado a dos revisores
- [x] He relacionado la PR con la Issue correspondiente

### Commits realizados
- Implementado manejo de errores con `ErrorApp` y `ErrorAppUI`
- Adaptado `ApiCall` al nuevo sistema de errores
